### PR TITLE
Search for package.json up the directory tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,20 @@ var fs = require('fs');
 var path = require('path');
 var xtend = require('xtend');
 var camelCase = require('camel-case');
+var pkginfo = require('pkginfo');
 
-function readPackage(cb){
-  var pkg = path.join(process.cwd(), 'package.json');
+function getPrefix(cb){
+  try {
+    var prefix = path.resolve(pkginfo.find(null, process.cwd()), '..');
+    return cb(null, prefix);
+  }
+  catch (err) {
+    return cb(err);
+  }
+}
+
+function readPackage(prefix, cb){
+  var pkg = path.join(prefix, 'package.json');
   fs.readFile(pkg, 'utf8', function(err, data){
     if(err){
       return cb(err);
@@ -26,13 +37,13 @@ function readPackage(cb){
   });
 }
 
-function loadPackages(packages, cb){
+function loadPackages(prefix, packages, cb){
   var loadedPackages = {};
   packages.forEach(function(pkg){
-    var pkgPath = path.resolve(process.cwd(), 'node_modules', pkg);
+    var pkgPath = path.resolve(prefix, 'node_modules', pkg);
     try {
       if(pkg.indexOf('.') > -1){
-        console.log('Naming', pkg,' as', pkg.replace(/\./g, '-'), 'in repl for ease of use');
+        console.log('Naming', pkg, 'as', pkg.replace(/\./g, '-'), 'in repl for ease of use');
         pkg = pkg.replace(/\./g, '-');
       }
       pkg = camelCase(pkg);
@@ -45,23 +56,29 @@ function loadPackages(packages, cb){
   cb(null, loadedPackages);
 }
 
-var replit = module.exports = function(){
-  readPackage(function(err, packages, projectName){
-    if(err){
-      console.log(err);
-      process.exit(1);
-    }
-    loadPackages(packages, function(err, pkgs){
-      if(err){
-        console.log(err);
-        process.exit(1);
-      } 
+function handleError(err){
+  if (err) {
+    console.log(err);
+    process.exit(1);
+  }
+}
 
-      var r = repl.start({
-        prompt: projectName+'> '
-      });
-      Object.keys(pkgs).forEach(function(p){
-        r.context[p] = pkgs[p];
+var replit = module.exports = function(){
+  getPrefix(function (err, prefix) {
+    handleError(err);
+
+    readPackage(prefix, function(err, packages, projectName){
+      handleError(err);
+
+      loadPackages(prefix, packages, function(err, pkgs){
+        handleError(err);
+
+        var r = repl.start({
+          prompt: projectName+'> '
+        });
+        Object.keys(pkgs).forEach(function(p){
+          r.context[p] = pkgs[p];
+        });
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/toddself/repl-it",
   "dependencies": {
     "camel-case": "^1.0.2",
+    "pkginfo": "^0.3.0",
     "xtend": "^4.0.0"
   }
 }


### PR DESCRIPTION
It would be nice not to have to start the REPL strictly from the package root, just like you can `npm install` or `npm ls` from any nested subdirectory.

I found that the algorithm NPM uses to traverse up to the root directory is [implemented](https://github.com/npm/npmconf/blob/master/lib/find-prefix.js) in [npmconf](https://www.npmjs.org/package/npmconf), but this module seems to do a dozen of other things, so I ended up using [pkginfo](https://www.npmjs.org/package/pkginfo) to [locate the package root](https://github.com/indexzero/node-pkginfo/blob/eeabe7e9c0c2c66fe6daf663b4d02bf41304a6ca/lib/pkginfo.js#L90-109). Unfortunately, it is still not focused enough, let me know if you know a better option.
