### PR TITLE
Remove superfluous dot handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,16 +38,12 @@ function readPackage(prefix, cb){
 }
 
 function getPackageDisplayName(pkg){
-  var newPkg;
-  if(pkg.indexOf('.') > -1){
-    newPkg = pkg.replace(/\./g, '-');
-  } 
-  newPkg = camelCase(pkg);
+  var newPkg = camelCase(pkg);
 
   if(pkg !== newPkg){
-    console.log('Naming', pkg, 'as', newPkg.replace(/\./g, '-'), 'in repl');
+    console.log('Naming', pkg, 'as', newPkg, 'in repl');
   }
-  
+
   return newPkg;
 }
 


### PR DESCRIPTION
Replacing dots with dashes is no longer necessary since [camel-case](https://www.npmjs.org/package/camel-case) is used here.

``` js
> camelCase('camel.case')
'camelCase'
> camelCase('camel-case')
'camelCase'
```
