### PR TITLE
Add --verbose CLI option

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,13 +85,13 @@ function parseOptions(){
   var options = {};
 
   process.argv.slice(2).forEach(function (arg) {
-    if (arg == '-v' || arg == '--verbose') {
+    if (arg === '-v' || arg === '--verbose') {
       if (options.verbose) {
         usage();
       }
       options.verbose = true;
     }
-    else if (arg == '--load-main') {
+    else if (arg === '--load-main') {
       if (options.loadMain) {
         usage();
       }


### PR DESCRIPTION
In most cases it is super obvious how `repl-it` is going to rename packages. This patch hides some info-level logging under `--verbose` option (or its `-v` shorthand).

P.S. Maybe it's the time to use one of external Node option parsers.
