### PR TITLE
Fix broken --loadmain

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var Replit = module.exports = function(opts){
           var pkgPath = path.resolve(prefix, projectMain);
           context[displayName] = require(pkgPath);
 
-          if(this.opts.verbose){
+          if(opts.verbose){
             console.log('Main package loaded as ' + displayName);
           }
 


### PR DESCRIPTION
As pointed out in [the comment](https://github.com/toddself/repl-it/pull/7#issuecomment-58570792), there is a context issue that makes `--loadmain` crash.

```
$ repl-it --loadmain

repl-it/index.js:34
          if(this.opts.verbose){
                 ^
TypeError: Cannot read property 'opts' of undefined
    at loadMain (repl-it/index.js:34:18)
    at null.<anonymous> (repl-it/index.js:42:11)
    at Replit.loadPackages (repl-it/index.js:126:6)
    at repl-it/index.js:24:20
    at repl-it/index.js:95:8
    at fs.js:271:14
    at Object.oncomplete (fs.js:107:15)
```
